### PR TITLE
Fixed negative money in island bank

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -449,10 +449,10 @@ public class IridiumSkyblock extends JavaPlugin {
                         }
                     }
                     for (Island island : getIslandManager().islands.values()) {
-                        int cm = island.money;
+                        double cm = island.money;
                         int cc = island.getCrystals();
                         int ce = island.exp;
-                        island.money = (int) Math.floor(island.money * (1 + (getConfiguration().dailyMoneyInterest / 100.00)));
+                        island.money = Math.floor(island.money * (1 + (getConfiguration().dailyMoneyInterest / 100.00)));
                         island.setCrystals((int) Math.floor(island.getCrystals() * (1 + (getConfiguration().dailyCrystalsInterest / 100.00))));
                         island.exp = (int) Math.floor(island.exp * (1 + (getConfiguration().dailyExpInterest / 100.00)));
                         for (String member : island.getMembers()) {

--- a/src/main/java/com/iridium/iridiumskyblock/Island.java
+++ b/src/main/java/com/iridium/iridiumskyblock/Island.java
@@ -124,7 +124,7 @@ public class Island {
 
     private String name;
 
-    public int money;
+    public double money;
     public int exp;
 
     public XBiome biome;

--- a/src/main/java/com/iridium/iridiumskyblock/gui/BankGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/BankGUI.java
@@ -117,12 +117,10 @@ public class BankGUI extends GUI implements Listener {
                         island.money += Vault.econ.getBalance(p);
                         Vault.econ.withdrawPlayer(p, Vault.econ.getBalance(p));
                     } else if (e.getClick().equals(ClickType.RIGHT)) {
-                        if (Vault.econ.getBalance(p) > 1000) {
-                            island.money += 1000;
-                            Vault.econ.withdrawPlayer(p, 1000);
-                        } else {
-                            island.money += Vault.econ.getBalance(p);
-                            Vault.econ.withdrawPlayer(p, Vault.econ.getBalance(p));
+                        double depositValue = Vault.econ.getBalance(p) > 1000 ? 1000: Vault.econ.getBalance(p);
+                        if(!(island.money > Double.MAX_VALUE - depositValue)){
+                            island.money += depositValue;
+                            Vault.econ.withdrawPlayer(p, depositValue);
                         }
                     } else if (e.getClick().equals(ClickType.LEFT)) {
                         if ((island.getPermissions((u.islandID == island.getId() || island.isCoop(u.getIsland())) ? (island.isCoop(u.getIsland()) ? Role.Member : u.getRole()) : Role.Visitor).withdrawBank) || u.bypassing) {


### PR DESCRIPTION
Basically, when you have deposited all your money in the bank with the shift+right clic option, if your money is higher than the integer's limit for java (2147483647), then the bank is filled with that value as maximum, but you will lose the rest of the money. In order to fix that, I just changed the type of the money variable of the Island class to double, in order to avoid future limit problems and thinking that nobody should be able to reach that value in a normal situation.

The other problem, if you had deposited up to the integer's limit as I said before, then if you try to deposit a value of 1000 with the normal right click option, the value will turn negative because of the filled 31 bits of 1's that cannot be added, except by modifying the signed bit of negative values, causing the number to be converted into a negative value because of all the carry bits. I have just added a check to be sure that if you are going to exceed that limit, then nothing happens.

I haven't check if there could be something more that could be affected by this change, and ignore the name of the commit, I'm just using the plugin in a prison server as cells, instead of islands, and I was distracted by that.