### PR TITLE
Fix onPlayerPortal for 1.8 support

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/onPlayerPortal.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/onPlayerPortal.java
@@ -19,7 +19,6 @@ public class onPlayerPortal implements Listener {
                 Island island = IridiumSkyblock.getIslandManager().getIslandViaLocation(e.getFrom());
                 if (island != null) {
                     if (island.getPermissions((u.islandID == island.getId() || island.isCoop(u.getIsland())) ? (island.isCoop(u.getIsland()) ? Role.Member : u.getRole()) : Role.Visitor).useNetherPortal || u.bypassing) {
-                        e.setCanCreatePortal(true);
                         if (e.getFrom().getWorld().equals(IridiumSkyblock.getIslandManager().getWorld())) {
                             e.setTo(island.getNetherhome());
                         } else {


### PR DESCRIPTION
This could be expanded to check the server version and only call it when the version is 1.14 or higher (couldn't find much about it, but it seems that this method got added in 1.14).