### PR TITLE
Fixed issue with Nether Islands.

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/Island.java
+++ b/src/main/java/com/iridium/iridiumskyblock/Island.java
@@ -1094,11 +1094,16 @@ public class Island {
                 entity.remove();
             }
         }
-        for (Entity entity : IridiumSkyblock.getIslandManager().getNetherWorld().getNearbyEntities(getCenter(), IridiumSkyblock.getUpgrades().sizeUpgrade.upgrades.get(sizeLevel).size / 2.00, 255, IridiumSkyblock.getUpgrades().sizeUpgrade.upgrades.get(sizeLevel).size / 2.00)) {
-            if (!entity.getType().equals(EntityType.PLAYER)) {
-                entity.remove();
-            }
-        }
+		if (IridiumSkyblock.getConfiguration().netherIslands) {
+		    Location netherCenter = getCenter().clone();
+		    netherCenter.setWorld(IridiumSkyblock.getIslandManager().getNetherWorld());
+
+			for (Entity entity : IridiumSkyblock.getIslandManager().getNetherWorld().getNearbyEntities(netherCenter, IridiumSkyblock.getUpgrades().sizeUpgrade.upgrades.get(sizeLevel).size / 2.00, 255, IridiumSkyblock.getUpgrades().sizeUpgrade.upgrades.get(sizeLevel).size / 2.00)) {
+				if (!entity.getType().equals(EntityType.PLAYER)) {
+					entity.remove();
+				}
+			}
+		}
     }
 
     public Location getNetherhome() {


### PR DESCRIPTION
Fixed issue with Nether Islands.

There are two bugs present this PR fixes relating to nether islands.

1. When nether islands are enabled and a player attempts to run /is home for the first time it throws a Different World error, it also results in player islands being placed at the same location when generated causing players to lose their island.
_Fix: The getCenter() method returns the center Location of the main Island, however the World set on this location is the main island world. As a result attempting to call getNearbyEntities on the nether island world while providing the center Location of the main island world results in a Different World error. Fixed this by cloning the `center` Location and changing the world on the clone to the nether island world._

2. When nether islands are disabled, running /is home throws a null pointer causing the same effects as above.
_Fix: A pretty straight forward issue, when the nether island feature is disabled, by default no nether island world is generated. As a result, creating an island attempts to call getNearbyEntities() on the nether island world as part of the killEntities() method, because no world has been generated the getNetherWorld() method returns null causing a NullPointerException when attempting to call getNearbyEntities() on null_

I've tested this and it appears to work fine with a fresh 1.15.2 Paper server.