### PR TITLE
Fix emerald duplication bug

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/gui/BankGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/BankGUI.java
@@ -68,8 +68,10 @@ public class BankGUI extends GUI implements Listener {
             if (e.getSlot() == (IridiumSkyblock.getInventories().crystals.slot == null ? 13 : IridiumSkyblock.getInventories().crystals.slot)) {
                 if (e.getClick().equals(ClickType.SHIFT_LEFT)) {
                     if ((island.getPermissions((u.islandID == island.getId() || island.isCoop(u.getIsland())) ? (island.isCoop(u.getIsland()) ? Role.Member : u.getRole()) : Role.Visitor).withdrawBank) || u.bypassing) {
-                        p.getInventory().addItem(Utils.getCrystals(island.getCrystals()));
-                        island.setCrystals(0);
+                        if (island.getCrystals() > 0) {
+                            p.getInventory().addItem(Utils.getCrystals(island.getCrystals()));
+                            island.setCrystals(0);
+                        }
                     }
                 } else if (e.getClick().equals(ClickType.SHIFT_RIGHT)) {
                     int i = 0;


### PR DESCRIPTION
This is a quickfix to prevent a weird bug which allowes players (at least in the 1.15.2, although this should not be related to any specific version) to get infinite amounts of emeralds when having 0 crystals by shift-left-clicking the item in the island bank GUI. 

May need some additional work to display an error message, but I have no idea how messages are handled internally by this plugin, but this should be patched as soon as possible. 