### PR TITLE
Fixed error with island positions

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/Island.java
+++ b/src/main/java/com/iridium/iridiumskyblock/Island.java
@@ -498,7 +498,7 @@ public class Island {
 
         final double minX = pos1.getX();
         final double minZ = pos1.getZ();
-        final double maxX = pos2.getZ();
+        final double maxX = pos2.getX();
         final double maxZ = pos2.getZ();
 
         final Map<String, Double> spawnerValueMap = blockValues.spawnervalue;


### PR DESCRIPTION
This typo made spawners redundant to island value. This is because the maxX was mistakenly using a Z coordinate from the pos2 variable. The x value of the spawner was then seen as out of range of the island and not within the X coordinates resulting in it not being counted towards total island value.