### PR TITLE
Fix for #152

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -17,7 +17,8 @@ public class PlayerTeleportListener implements Listener {
             final IslandManager islandManager = IridiumSkyblock.getIslandManager();
             final Island island = islandManager.getIslandViaLocation(toLocation);
             if (island == null) return;
-
+            Island fromIsland = islandManager.getIslandViaLocation(event.getFrom());
+            if (fromIsland != null && fromIsland.getId() == island.getId()) return;
             final Player player = event.getPlayer();
             final User user = User.getUser(player);
 


### PR DESCRIPTION
Add an extra if statement in the onPlayerTeleport Listener, that checks if the player's event.getFrom() location isn't on the same island as the island at the event.getTo() location.