### PR TITLE
Fix random teleportation message

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -14,6 +14,7 @@ public class PlayerTeleportListener implements Listener {
     public void onPlayerTeleport(PlayerTeleportEvent event) {
         try {
             final Location toLocation = event.getTo();
+            final Location fromLocation = event.getFrom();
             final IslandManager islandManager = IridiumSkyblock.getIslandManager();
             final Island island = islandManager.getIslandViaLocation(toLocation);
             if (island == null) return;
@@ -22,6 +23,8 @@ public class PlayerTeleportListener implements Listener {
             final User user = User.getUser(player);
 
             if (user.islandID == island.getId()) return;
+
+            if (toLocation.getWorld() == fromLocation.getWorld() && toLocation.distance(fromLocation) < 1) return;
 
             if ((island.isVisit() && !island.isBanned(user)) || user.bypassing) {
                 Bukkit.getScheduler().scheduleSyncDelayedTask(IridiumSkyblock.getInstance(), () -> island.sendBorder(player), 1);


### PR DESCRIPTION
This pull request fixes a bug that occurred when Spigot corrected the location of players by teleportation, e.g. when they stand in an iron door while it is closing or open a trapdoor without permissions (according to my players, the last example only occurred under certain conditions). 

For some reason, these corrections trigger the PlayerTeleportEvent. I don't know whether this is a bug in Spigot (Paper) 1.15.2 or not, but I don't think so. 

These changes ignore teleportations whose distances are less than 1 block. After one day of testing, this seems to fix the issue completely.