### PR TITLE
Fixed island value with spawners

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/Island.java
+++ b/src/main/java/com/iridium/iridiumskyblock/Island.java
@@ -471,8 +471,8 @@ public class Island {
             final Optional<XMaterial> xmaterial = XMaterial.matchXMaterial(item);
             if (!xmaterial.isPresent()) continue;
 
-            final BigDecimal blockValue = BigDecimal.valueOf(blockValueMap.get(xmaterial.get()));
             if (!blockValueMap.containsKey(xmaterial.get())) continue;
+            final BigDecimal blockValue = BigDecimal.valueOf(blockValueMap.get(xmaterial.get()));
 
             value = value.add(blockValue.multiply(amount));
         }


### PR DESCRIPTION
Having the if statement after was causing a NullPointerException when a valuable block was placed and a spawner was present on the island.