### PR TITLE
Fix nether portal cross linking

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
@@ -23,6 +23,7 @@ public class Config {
     public boolean automaticUpdate = true;
     public boolean defaultIslandPublic = true;
     public boolean netherIslands = true;
+    public boolean forceShortPortalRadius = true;
     public boolean islandMenu = true;
     public boolean voidTeleport = true;
     public boolean notifyAvailableUpdate = true;
@@ -80,4 +81,5 @@ public class Config {
     public List<XBiome> biomes = Arrays.asList(XBiome.values());
 
     public List<EntityType> blockedEntities = Arrays.asList(EntityType.PRIMED_TNT, EntityType.MINECART_TNT, EntityType.FIREBALL, EntityType.SMALL_FIREBALL, EntityType.ENDER_PEARL);
+
 }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerPortalListener.java
@@ -19,7 +19,7 @@ public class PlayerPortalListener implements Listener {
     @EventHandler
     public void onPlayerPortal(PlayerPortalEvent event) {
         try {
-            final Location fromLocation = event.getFrom();
+            final Location fromLocation = event.getFrom().clone();
             final IslandManager islandManager = IridiumSkyblock.getIslandManager();
             final Island island = islandManager.getIslandViaLocation(fromLocation);
             if (island == null) return;
@@ -55,6 +55,11 @@ public class PlayerPortalListener implements Listener {
             if (world == null) return;
 
             final String worldName = world.getName();
+            // This setting forces portal search radius to 16, avoiding conflicts with bordering portals
+            // (May have unintended consequences...?)
+            if(IridiumSkyblock.getConfiguration().forceShortPortalRadius)
+                event.setSearchRadius(16);
+
             if (worldName.equals(IridiumSkyblock.getConfiguration().worldName))
                 event.setTo(island.getNetherhome());
             else if (worldName.equals(IridiumSkyblock.getConfiguration().netherWorldName))


### PR DESCRIPTION
This PR allows a config option to force the nether portal search radius to 16. By default in 1.16 it's 128, and can cause a cross-linking issue quite easily on the default island sizes.