### PR TITLE
Make mission condition names more convenient

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/EntityDeathListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/EntityDeathListener.java
@@ -38,7 +38,7 @@ public class EntityDeathListener implements Listener {
                 if (level.type != MissionType.ENTITY_KILL) continue;
 
                 final List<String> conditions = level.conditions;
-                if (conditions.isEmpty() || conditions.contains(entity.toString()))
+                if (conditions.isEmpty() || conditions.contains(entity.toString()) || conditions.contains(entity.toString().replace("Craft", "")))
                     userIsland.addMission(mission.name, 1);
             }
 


### PR DESCRIPTION
This PR will "fix" #202 by optionally enabling support for convenient mission conditions like "Pig" instead of "CraftPig" without breaking compatibility for users who are using the current condition names.