### PR TITLE
Allow players to eat on islands again

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerInteractListener.java
@@ -58,8 +58,6 @@ public class PlayerInteractListener implements Listener {
                     event.setCancelled(true);
                     return;
                 }
-            } else {
-                event.setCancelled(true);
             }
         } catch (Exception e) {
             IridiumSkyblock.getInstance().sendErrorMessage(e);


### PR DESCRIPTION
This setCancelled stops players from eating on any island without eating against a block, because if they hold right click to eat against no block, the event always gets cancelled. I don't see any specific use cases for this event.setCancelled, so potentially this is just a bug fix.