### PR TITLE
Improve spy command

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTalkListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTalkListener.java
@@ -10,8 +10,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
-import java.util.stream.Collectors;
-
 public class PlayerTalkListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
@@ -77,16 +75,18 @@ public class PlayerTalkListener implements Listener {
                             .replace("%player%", player.getName())
                             .replace("%message%", event.getMessage()));
                 }
-                for (Player spyingPlayer : Bukkit.getServer().getOnlinePlayers().stream().filter(onlinePlayer -> User.getUser(onlinePlayer).spyingIslandsChat).collect(Collectors.toList()))
-                {
-                    spyingPlayer.sendMessage(Utils.color(IridiumSkyblock.getMessages().spyChatFormat)
+                Bukkit.getServer().getOnlinePlayers().stream()
+                  .filter(onlinePlayer -> User.getUser(onlinePlayer).spyingIslandsChat)
+                  .forEach((spyingPlayer) -> {
+                        spyingPlayer.sendMessage(Utils.color(IridiumSkyblock.getMessages().spyChatFormat)
                             .replace(IridiumSkyblock.getConfiguration().chatValuePlaceholder, island.getFormattedValue())
                             .replace(IridiumSkyblock.getConfiguration().chatNAMEPlaceholder, island.getName())
                             .replace(IridiumSkyblock.getConfiguration().chatLevelPlaceholder, island.getFormattedValue())
                             .replace(IridiumSkyblock.getConfiguration().chatRankPlaceholder, Utils.getIslandRank(island) + "")
                             .replace("%player%", player.getName())
                             .replace("%message%", event.getMessage()));
-                }
+
+                  });
                 event.setCancelled(true);
             }
 


### PR DESCRIPTION
This PR will make the spy command a bit more performant by using the Stream API to loop through the spying players instead of collecting them from the stream and iterating over them in another for-loop.