### PR TITLE
Fix placeholders to get custom island names in top_name_X

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
@@ -53,6 +53,7 @@ public class Config {
     public boolean keepInventoryOnVoid = true;
     public boolean createIslandOnJoin = false;
     public boolean ignoreCooldownOnJoinCreation = false;
+    public boolean stripTopIslandPlaceholderColors = true;
     public int deleteBackupsAfterDays = 7;
     public int regenCooldown = 3600;
     public int distance = 151;

--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/ClipPlaceholderAPIManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/ClipPlaceholderAPIManager.java
@@ -117,18 +117,18 @@ public class ClipPlaceholderAPIManager extends PlaceholderExpansion {
             case "midnight_hours":
                 return hours + "";
         }
-        if (placeholder.startsWith("island_top_island_")) {
+        if (placeholder.startsWith("island_top_name_")) {
             try {
-                Integer integer = Integer.parseInt(placeholder.replace("island_top_island_", ""));
+                Integer integer = Integer.parseInt(placeholder.replace("island_top_name_", ""));
                 List<Island> islands = Utils.getTopIslands();
                 return islands.size() > integer - 1 ? phCheckIfStripped(Utils.getTopIslands().get(integer - 1).getName()) : IridiumSkyblock.getConfiguration().placeholderDefaultValue;
             } catch (NumberFormatException e) {
                 e.printStackTrace();
             }
         }
-        if (placeholder.startsWith("island_top_name_")) {
+        if (placeholder.startsWith("island_top_owner_")) {
             try {
-                Integer integer = Integer.parseInt(placeholder.replace("island_top_name_", ""));
+                Integer integer = Integer.parseInt(placeholder.replace("island_top_owner_", ""));
                 List<Island> islands = Utils.getTopIslands();
                 return islands.size() > integer - 1 ? User.getUser(Utils.getTopIslands().get(integer - 1).getOwner()).name : IridiumSkyblock.getConfiguration().placeholderDefaultValue;
             } catch (NumberFormatException e) {

--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/ClipPlaceholderAPIManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/ClipPlaceholderAPIManager.java
@@ -7,6 +7,7 @@ import com.iridium.iridiumskyblock.User;
 import com.iridium.iridiumskyblock.Utils;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import java.text.NumberFormat;
@@ -116,6 +117,15 @@ public class ClipPlaceholderAPIManager extends PlaceholderExpansion {
             case "midnight_hours":
                 return hours + "";
         }
+        if (placeholder.startsWith("island_top_island_")) {
+            try {
+                Integer integer = Integer.parseInt(placeholder.replace("island_top_island_", ""));
+                List<Island> islands = Utils.getTopIslands();
+                return islands.size() > integer - 1 ? phCheckIfStripped(Utils.getTopIslands().get(integer - 1).getName()) : IridiumSkyblock.getConfiguration().placeholderDefaultValue;
+            } catch (NumberFormatException e) {
+                e.printStackTrace();
+            }
+        }
         if (placeholder.startsWith("island_top_name_")) {
             try {
                 Integer integer = Integer.parseInt(placeholder.replace("island_top_name_", ""));
@@ -145,4 +155,12 @@ public class ClipPlaceholderAPIManager extends PlaceholderExpansion {
         }
         return null;
     }
+
+    public String phCheckIfStripped(String ph) {
+        if (IridiumSkyblock.getConfiguration().stripTopIslandPlaceholderColors) {
+            return ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', ph)).replace("\"","\\\"");
+        }
+        return ph.replace("\"","\\\"");
+    }
+
 }

--- a/src/main/java/com/iridium/iridiumskyblock/placeholders/MVDWPlaceholderAPIManager.java
+++ b/src/main/java/com/iridium/iridiumskyblock/placeholders/MVDWPlaceholderAPIManager.java
@@ -6,6 +6,7 @@ import com.iridium.iridiumskyblock.Island;
 import com.iridium.iridiumskyblock.User;
 import com.iridium.iridiumskyblock.Utils;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import java.text.NumberFormat;
@@ -258,9 +259,13 @@ public class MVDWPlaceholderAPIManager {
 
         for (int i = 0; i < 10; i++) { //TODO there is probably a more efficient way to do this?
             int finalI = i;
-            PlaceholderAPI.registerPlaceholder(IridiumSkyblock.getInstance(), "iridiumskyblock_island_top_name_" + (i + 1), e -> {
+            PlaceholderAPI.registerPlaceholder(IridiumSkyblock.getInstance(), "iridiumskyblock_island_top_owner_" + (i + 1), e -> {
                 List<Island> islands = Utils.getTopIslands();
                 return islands.size() > finalI ? User.getUser(Utils.getTopIslands().get(finalI).getOwner()).name : IridiumSkyblock.getConfiguration().placeholderDefaultValue;
+            });
+            PlaceholderAPI.registerPlaceholder(IridiumSkyblock.getInstance(), "iridiumskyblock_island_top_name_" + (i + 1), e -> {
+                List<Island> islands = Utils.getTopIslands();
+                return islands.size() > finalI ? phCheckIfStripped(Utils.getTopIslands().get(finalI).getName()) : IridiumSkyblock.getConfiguration().placeholderDefaultValue;
             });
             PlaceholderAPI.registerPlaceholder(IridiumSkyblock.getInstance(), "iridiumskyblock_island_top_value_" + (i + 1), e -> {
                 List<Island> islands = Utils.getTopIslands();
@@ -271,5 +276,12 @@ public class MVDWPlaceholderAPIManager {
                 return islands.size() > finalI ? Utils.NumberFormatter.format(Math.floor(Utils.getTopIslands().get(finalI).getValue() / IridiumSkyblock.getConfiguration().valuePerLevel)) : IridiumSkyblock.getConfiguration().placeholderDefaultValue;
             });
         }
+    }
+
+    public String phCheckIfStripped(String ph) {
+        if (IridiumSkyblock.getConfiguration().stripTopIslandPlaceholderColors) {
+            return ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', ph)).replace("\"","\\\"");
+        }
+        return ph.replace("\"","\\\"");
     }
 }


### PR DESCRIPTION
- `..top_name_X` now returns the name of the island set with /is setname
- `..top_owner_X` now returns the name of the island owner.
- Added config option to optionally strip color formatting to preserve hologram designs. This additional function also escapes quotes to prevent errors/failure as PAPI throws an exception if an island name has a double quote in it.