### PR TITLE
Blockstacking on/off, container bugfix, optional list of stackable blocks

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -59,6 +59,8 @@ public class IridiumSkyblock extends JavaPlugin {
     @Getter
     public static BlockValues blockValues;
     @Getter
+    public static Stackable stackable;
+    @Getter
     public static Shop shop;
     public static TopGUI topGUI;
     @Getter
@@ -633,6 +635,7 @@ public class IridiumSkyblock extends JavaPlugin {
         blockValues = persist.getFile(BlockValues.class).exists() ? persist.load(BlockValues.class) : new BlockValues();
         shop = persist.getFile(Shop.class).exists() ? persist.load(Shop.class) : new Shop();
         border = persist.getFile(Border.class).exists() ? persist.load(Border.class) : new Border();
+        stackable = persist.getFile(Stackable.class).exists() ? persist.load(Stackable.class) : new Stackable();
 
         if (inventories.red.slot == null) inventories.red.slot = 10;
         if (inventories.green.slot == null) inventories.green.slot = 12;
@@ -648,7 +651,7 @@ public class IridiumSkyblock extends JavaPlugin {
         commandManager = new CommandManager("island");
         commandManager.registerCommands();
 
-        if (configuration == null || missions == null || messages == null || upgrades == null || boosters == null || inventories == null || schematics == null || commands == null || blockValues == null || shop == null) {
+        if (configuration == null || missions == null || messages == null || upgrades == null || boosters == null || inventories == null || schematics == null || commands == null || blockValues == null || shop == null || stackable == null) {
             return false;
         }
 
@@ -724,6 +727,10 @@ public class IridiumSkyblock extends JavaPlugin {
             getBlockValues().blockvalue = new HashMap<>(getConfiguration().blockvalue);
             getConfiguration().blockvalue = null;
         }
+        if (getConfiguration().stackable != null) {
+            getStackable().blockList = new ArrayList<>(getConfiguration().stackable);
+            getStackable().blockList = null;
+        }
         if (getConfiguration().spawnervalue != null) {
             getBlockValues().spawnervalue = new HashMap<>(getConfiguration().spawnervalue);
             getConfiguration().spawnervalue = null;
@@ -790,6 +797,7 @@ public class IridiumSkyblock extends JavaPlugin {
             if (blockValues != null) persist.save(blockValues);
             if (shop != null) persist.save(shop);
             if (border != null) persist.save(border);
+            if (stackable != null) persist.save(stackable);
         });
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
@@ -53,6 +53,8 @@ public class Config {
     public boolean keepInventoryOnVoid = true;
     public boolean createIslandOnJoin = false;
     public boolean ignoreCooldownOnJoinCreation = false;
+    public boolean enableBlockStacking = true;
+    public boolean useStackableList = false;
     public int deleteBackupsAfterDays = 7;
     public int regenCooldown = 3600;
     public int distance = 151;
@@ -101,6 +103,7 @@ public class Config {
 
     public Map<XMaterial, Double> blockvalue = null;
     public Map<String, Double> spawnervalue = null;
+    public List<XMaterial> stackable = null;
     public List<XBiome> biomes = null;
     public Map<XBiome, BiomeConfig> islandBiomes = new HashMap<XBiome, BiomeConfig>() {{
         for (XBiome biome : XBiome.VALUES.stream().filter(biome -> !biome.equals(XBiome.THE_VOID)).collect(Collectors.toList())) {

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Stackable.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Stackable.java
@@ -1,0 +1,22 @@
+package com.iridium.iridiumskyblock.configs;
+
+import com.cryptomorin.xseries.XMaterial;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class Stackable {
+
+    public List<XMaterial> blockList = new ArrayList() {{
+            add(XMaterial.IRON_BLOCK);
+            add(XMaterial.GOLD_BLOCK);
+            add(XMaterial.DIAMOND_BLOCK);
+            add(XMaterial.EMERALD_BLOCK);
+            add(XMaterial.NETHERITE_BLOCK);
+    }};
+
+    public List<XMaterial> getStackable() {
+        return blockList;
+    }
+
+}

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BlockPlaceListener.java
@@ -9,6 +9,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.Container;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -82,8 +83,9 @@ public class BlockPlaceListener implements Listener {
                 if (config.enableBlockStacking) {
                     Boolean canStack = false;
 
-                    if ((config.useStackableList && IridiumSkyblock.getStackable().blockList.contains(XMaterial.matchXMaterial(event.getBlock().getType()))) ||
-                            (!config.useStackableList && IridiumSkyblock.getBlockValues().blockvalue.containsKey(XMaterial.matchXMaterial(event.getBlock().getType())))) {
+                    if (((config.useStackableList && IridiumSkyblock.getStackable().blockList.contains(XMaterial.matchXMaterial(event.getBlock().getType()))) ||
+                            (!config.useStackableList && IridiumSkyblock.getBlockValues().blockvalue.containsKey(XMaterial.matchXMaterial(event.getBlock().getType())))) &&
+                                    !(event.getBlock().getState() instanceof Container)) {
                         canStack = true;
                     }
 

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/BlockPlaceListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/BlockPlaceListener.java
@@ -79,13 +79,22 @@ public class BlockPlaceListener implements Listener {
             if (!island.getPermissions(user).placeBlocks) {
                 event.setCancelled(true);
             } else {
-                if (player.isSneaking() && event.getBlockAgainst().getType() == event.getBlock().getType() && IridiumSkyblock.getBlockValues().blockvalue.containsKey(XMaterial.matchXMaterial(event.getBlock().getType()))) {
-                    island.stackedBlocks.compute(event.getBlockAgainst().getLocation(), (loc, original) -> {
-                        if (original == null) return 2;
-                        return original + 1;
-                    });
-                    Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> island.sendHomograms());
-                    Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> block.setType(Material.AIR, false));
+                if (config.enableBlockStacking) {
+                    Boolean canStack = false;
+
+                    if ((config.useStackableList && IridiumSkyblock.getStackable().blockList.contains(XMaterial.matchXMaterial(event.getBlock().getType()))) ||
+                            (!config.useStackableList && IridiumSkyblock.getBlockValues().blockvalue.containsKey(XMaterial.matchXMaterial(event.getBlock().getType())))) {
+                        canStack = true;
+                    }
+
+                    if (player.isSneaking() && event.getBlockAgainst().getType() == event.getBlock().getType() && canStack) {
+                        island.stackedBlocks.compute(event.getBlockAgainst().getLocation(), (loc, original) -> {
+                            if (original == null) return 2;
+                            return original + 1;
+                        });
+                        Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> island.sendHomograms());
+                        Bukkit.getScheduler().runTask(IridiumSkyblock.getInstance(), () -> block.setType(Material.AIR, false));
+                    }
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Adds two config options:

- `enableBlockStacking` (default true) Turns block stacking on/off. Only functions for BlockPlaceListener to preserve existing stacks if this feature is turned off after stacks are already made.
- `useStackableList` (default false, creates _stackable.json_) toggles between using _blockvalues.json_ OR _stackable.json_ to check if blocks should be stacked.
- Prevents stacking of container blocks so that double chests, hopper chains, etc. can be placed properly and not stack.