### PR TITLE
Fix bypassing users being kicked when owner does /is private

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
@@ -25,7 +25,7 @@ public class PrivateCommand extends Command {
                 user.getIsland().setVisit(false);
                 int visitorCount = 0;
                 for (Player visitor : user.getIsland().getPlayersOnIsland()) {
-                    if (user.getIsland().equals(User.getUser(visitor).getIsland())) continue;
+                    if (user.getIsland().equals(User.getUser(visitor).getIsland()) || User.getUser(visitor).bypassing) continue;
                     user.getIsland().spawnPlayer(visitor);
                     visitor.sendMessage(Utils.color(IridiumSkyblock.getMessages().expelledIslandLocked
                             .replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)

--- a/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
@@ -25,7 +25,7 @@ public class PrivateCommand extends Command {
                 user.getIsland().setVisit(false);
                 int visitorCount = 0;
                 for (Player visitor : user.getIsland().getPlayersOnIsland()) {
-                    if (user.getIsland().equals(User.getUser(visitor).getIsland()) || User.getUser(visitor).bypassing) continue;
+                    if (user.getIsland().equals(User.getUser(visitor).getIsland()) || User.getUser(visitor).bypassing || user.getIsland().isCoop(User.getUser(visitor).getIsland())) continue;
                     user.getIsland().spawnPlayer(visitor);
                     visitor.sendMessage(Utils.color(IridiumSkyblock.getMessages().expelledIslandLocked
                             .replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)


### PR DESCRIPTION
Stops users in bypass being kicked from islands if the owner performs /is private while they're on it.