### PR TITLE
Shop bugfixes and additions

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/Utils.java
+++ b/src/main/java/com/iridium/iridiumskyblock/Utils.java
@@ -427,9 +427,9 @@ public class Utils {
             }
         }
         if (IridiumSkyblock.getInstance().getEconomy() != null) {
-            if (IridiumSkyblock.getInstance().getEconomy().getBalance(p) >= vault) {
+            if (IridiumSkyblock.getInstance().getEconomy().getBalance(p) >= vault && crystals == 0) {
                 IridiumSkyblock.getInstance().getEconomy().withdrawPlayer(p, vault);
-                TransactionLogger.saveTransaction(p, new Transaction().add(TransactionType.MONEY, -vault).add(TransactionType.CRYSTALS, -crystals));
+                TransactionLogger.saveTransaction(p, new Transaction().add(TransactionType.MONEY, -vault));
                 return BuyResponce.SUCCESS;
             }
             return BuyResponce.NOT_ENOUGH_VAULT;

--- a/src/main/java/com/iridium/iridiumskyblock/Utils.java
+++ b/src/main/java/com/iridium/iridiumskyblock/Utils.java
@@ -516,8 +516,7 @@ public class Utils {
     }
 
     public static boolean hasOpenSlot(Inventory inv) {
-        if (inv.firstEmpty() == -1) return false;
-        return true;
+        return (inv.firstEmpty() == -1) ? false : true;
     }
 
     public static XMaterial getXMaterialFromId(int id, byte data) {

--- a/src/main/java/com/iridium/iridiumskyblock/Utils.java
+++ b/src/main/java/com/iridium/iridiumskyblock/Utils.java
@@ -427,11 +427,12 @@ public class Utils {
             }
         }
         if (IridiumSkyblock.getInstance().getEconomy() != null) {
-            if (IridiumSkyblock.getInstance().getEconomy().getBalance(p) >= vault && crystals == 0) {
+            if (IridiumSkyblock.getInstance().getEconomy().getBalance(p) >= vault) {
                 IridiumSkyblock.getInstance().getEconomy().withdrawPlayer(p, vault);
-                TransactionLogger.saveTransaction(p, new Transaction().add(TransactionType.MONEY, -vault));
+                TransactionLogger.saveTransaction(p, new Transaction().add(TransactionType.MONEY, -vault).add(TransactionType.CRYSTALS, -crystals));
                 return BuyResponce.SUCCESS;
             }
+            return BuyResponce.NOT_ENOUGH_VAULT;
         }
         return crystals == 0 ? BuyResponce.NOT_ENOUGH_VAULT : BuyResponce.NOT_ENOUGH_CRYSTALS;
     }
@@ -515,14 +516,8 @@ public class Utils {
     }
 
     public static boolean hasOpenSlot(Inventory inv) {
-        for (ItemStack item : inv.getContents()) {
-            if (item == null) {
-                return true;
-            } else if (item.getType() == Material.AIR) {
-                return true;
-            }
-        }
-        return false;
+        if (inv.firstEmpty() == -1) return false;
+        return true;
     }
 
     public static XMaterial getXMaterialFromId(int id, byte data) {

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Messages.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Messages.java
@@ -114,6 +114,7 @@ public class Messages {
     public String islandDeleted = "%prefix% &7Your island has been deleted";
     public String mustBeInIsland = "%prefix% &7You must be in your island to do this.";
     public String cannotSellItem = "%prefix% &7This is not a sellable item.";
+    public String cannotBuyItem = "%prefix% &7This is not a buyable item.";
     public String blockLimitReached = "%prefix% &7The island limit for this block has already been reached";
     public String unknownCommand = "%prefix% &7Unknown Command, Try /is help";
     public String noPermissionBuild = "%prefix% &7You do not have permission to build on this island";

--- a/src/main/java/com/iridium/iridiumskyblock/gui/ShopGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/ShopGUI.java
@@ -212,7 +212,7 @@ public class ShopGUI extends GUI implements Listener {
                                             .replace("%money%", Utils.NumberFormatter.format(item.buyVault))));
                                 }
                             } else {
-                                e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT ? IridiumSkyblock.getMessages().cantBuy.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix) : IridiumSkyblock.getMessages().notEnoughCrystals).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
+                                e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT ? IridiumSkyblock.getMessages().cantBuy : IridiumSkyblock.getMessages().notEnoughCrystals).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                             }
                         } else {
                             e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().cannotBuyItem.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));

--- a/src/main/java/com/iridium/iridiumskyblock/gui/ShopGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/ShopGUI.java
@@ -244,7 +244,7 @@ public class ShopGUI extends GUI implements Listener {
                                             .replace("%money%", Utils.NumberFormatter.format(buyVault))));
                                 }
                             } else {
-                                e.getWhoClicked().sendMessage(Utils.color(responce == Utils.BuyResponce.NOT_ENOUGH_VAULT ? IridiumSkyblock.getMessages().cantBuy : IridiumSkyblock.getMessages().notEnoughCrystals.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
+                                e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT ? IridiumSkyblock.getMessages().cantBuy : IridiumSkyblock.getMessages().notEnoughCrystals).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                             }
                         } else {
                             e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().cannotBuyItem.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));

--- a/src/main/java/com/iridium/iridiumskyblock/gui/ShopGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/ShopGUI.java
@@ -211,7 +211,7 @@ public class ShopGUI extends GUI implements Listener {
                                         .replace("%money%", Utils.NumberFormatter.format(item.buyVault))));
                             }
                         } else {
-                            e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT ? IridiumSkyblock.getMessages().cantBuy : IridiumSkyblock.getMessages().notEnoughCrystals).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
+                            e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT) ? IridiumSkyblock.getMessages().cantBuy.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix) : IridiumSkyblock.getMessages().notEnoughCrystals.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                         }
                     } else if (e.getClick().equals(ClickType.SHIFT_LEFT)) {
                         //If we are running commands we dont want to charge them 64x the price since we dont stack buy commands
@@ -239,7 +239,7 @@ public class ShopGUI extends GUI implements Listener {
                                         .replace("%money%", Utils.NumberFormatter.format(buyVault))));
                             }
                         } else {
-                            e.getWhoClicked().sendMessage(Utils.color(responce == Utils.BuyResponce.NOT_ENOUGH_VAULT ? IridiumSkyblock.getMessages().cantBuy : IridiumSkyblock.getMessages().notEnoughCrystals.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
+                            e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT) ? IridiumSkyblock.getMessages().cantBuy.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix) : IridiumSkyblock.getMessages().notEnoughCrystals.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                         }
                     }
                 }

--- a/src/main/java/com/iridium/iridiumskyblock/gui/ShopGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/ShopGUI.java
@@ -189,57 +189,65 @@ public class ShopGUI extends GUI implements Listener {
                             e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().cannotSellItem.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                         }
                     } else if (e.getClick().equals(ClickType.LEFT)) {
-                        Utils.BuyResponce responce = Utils.canBuy((Player) e.getWhoClicked(), item.buyVault, item.buyCrystals);
-                        if (responce == Utils.BuyResponce.SUCCESS) {
-                            if (item.commands != null) {
-                                for (String Command : item.commands) {
-                                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), Command.replace("%player%", e.getWhoClicked().getName()));
+                        if (item.buyVault > 0 || item.buyCrystals > 0) {
+                            Utils.BuyResponce responce = Utils.canBuy((Player) e.getWhoClicked(), item.buyVault, item.buyCrystals);
+                            if (responce == Utils.BuyResponce.SUCCESS) {
+                                if (item.commands != null) {
+                                    for (String Command : item.commands) {
+                                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), Command.replace("%player%", e.getWhoClicked().getName()));
+                                    }
+                                } else {
+                                    ItemStack itemStack = item.material.parseItem();
+                                    itemStack.setAmount(item.amount);
+                                    if (Utils.hasOpenSlot(e.getWhoClicked().getInventory())) {
+                                        e.getWhoClicked().getInventory().addItem(itemStack);
+                                    } else {
+                                        e.getWhoClicked().getLocation().getWorld().dropItem(e.getWhoClicked().getLocation(), itemStack);
+                                    }
+                                    e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().shopBoughtMessage
+                                            .replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)
+                                            .replace("%item%", item.material + "")
+                                            .replace("%amount%", item.amount + "")
+                                            .replace("%crystals%", Utils.NumberFormatter.format(item.buyCrystals))
+                                            .replace("%money%", Utils.NumberFormatter.format(item.buyVault))));
                                 }
                             } else {
-                                ItemStack itemStack = item.material.parseItem();
-                                itemStack.setAmount(item.amount);
-                                if (Utils.hasOpenSlot(e.getWhoClicked().getInventory())) {
-                                    e.getWhoClicked().getInventory().addItem(itemStack);
-                                } else {
-                                    e.getWhoClicked().getLocation().getWorld().dropItem(e.getWhoClicked().getLocation(), itemStack);
-                                }
-                                e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().shopBoughtMessage
-                                        .replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)
-                                        .replace("%item%", item.material + "")
-                                        .replace("%amount%", item.amount + "")
-                                        .replace("%crystals%", Utils.NumberFormatter.format(item.buyCrystals))
-                                        .replace("%money%", Utils.NumberFormatter.format(item.buyVault))));
+                                e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT ? IridiumSkyblock.getMessages().cantBuy.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix) : IridiumSkyblock.getMessages().notEnoughCrystals).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                             }
                         } else {
-                            e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT) ? IridiumSkyblock.getMessages().cantBuy.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix) : IridiumSkyblock.getMessages().notEnoughCrystals.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
+                            e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().cannotBuyItem.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                         }
                     } else if (e.getClick().equals(ClickType.SHIFT_LEFT)) {
-                        //If we are running commands we dont want to charge them 64x the price since we dont stack buy commands
-                        double buyVault = item.commands != null ? item.buyVault : (item.buyVault / item.amount) * 64;
-                        int buyCrystals = item.commands != null ? item.buyCrystals : (int) Math.floor((item.buyCrystals / (double) item.amount) * 64);
-                        Utils.BuyResponce responce = Utils.canBuy((Player) e.getWhoClicked(), buyVault, buyCrystals);
-                        if (responce == Utils.BuyResponce.SUCCESS) {
-                            if (item.commands != null) {
-                                for (String Command : item.commands) {
-                                    Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), Command.replace("%player%", e.getWhoClicked().getName()));
+                        if (item.buyVault > 0 || item.buyCrystals > 0) {
+                            //If we are running commands we dont want to charge them 64x the price since we dont stack buy commands
+                            double buyVault = item.commands != null ? item.buyVault : (item.buyVault / item.amount) * 64;
+                            int buyCrystals = item.commands != null ? item.buyCrystals : (int) Math.floor((item.buyCrystals / (double) item.amount) * 64);
+                            Utils.BuyResponce responce = Utils.canBuy((Player) e.getWhoClicked(), buyVault, buyCrystals);
+                            if (responce == Utils.BuyResponce.SUCCESS) {
+                                if (item.commands != null) {
+                                    for (String Command : item.commands) {
+                                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), Command.replace("%player%", e.getWhoClicked().getName()));
+                                    }
+                                } else {
+                                    ItemStack itemStack = item.material.parseItem();
+                                    itemStack.setAmount(64);
+                                    if (Utils.hasOpenSlot(e.getWhoClicked().getInventory())) {
+                                        e.getWhoClicked().getInventory().addItem(itemStack);
+                                    } else {
+                                        e.getWhoClicked().getLocation().getWorld().dropItem(e.getWhoClicked().getLocation(), itemStack);
+                                    }
+                                    e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().shopBoughtMessage
+                                            .replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)
+                                            .replace("%item%", item.material + "")
+                                            .replace("%amount%", 64 + "")
+                                            .replace("%crystals%", Utils.NumberFormatter.format(buyCrystals))
+                                            .replace("%money%", Utils.NumberFormatter.format(buyVault))));
                                 }
                             } else {
-                                ItemStack itemStack = item.material.parseItem();
-                                itemStack.setAmount(64);
-                                if (Utils.hasOpenSlot(e.getWhoClicked().getInventory())) {
-                                    e.getWhoClicked().getInventory().addItem(itemStack);
-                                } else {
-                                    e.getWhoClicked().getLocation().getWorld().dropItem(e.getWhoClicked().getLocation(), itemStack);
-                                }
-                                e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().shopBoughtMessage
-                                        .replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)
-                                        .replace("%item%", item.material + "")
-                                        .replace("%amount%", 64 + "")
-                                        .replace("%crystals%", Utils.NumberFormatter.format(buyCrystals))
-                                        .replace("%money%", Utils.NumberFormatter.format(buyVault))));
+                                e.getWhoClicked().sendMessage(Utils.color(responce == Utils.BuyResponce.NOT_ENOUGH_VAULT ? IridiumSkyblock.getMessages().cantBuy : IridiumSkyblock.getMessages().notEnoughCrystals.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                             }
                         } else {
-                            e.getWhoClicked().sendMessage(Utils.color((responce == Utils.BuyResponce.NOT_ENOUGH_VAULT) ? IridiumSkyblock.getMessages().cantBuy.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix) : IridiumSkyblock.getMessages().notEnoughCrystals.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
+                            e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().cannotBuyItem.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                         }
                     }
                 }


### PR DESCRIPTION
- Fix: items were not dropping at the player if they had a full inventory when buying, but money and crystals were still taken.
- Improved inventory check in hasOpenSlot() (1.8+ compatible).
- Correct responses now sent depending on if the player doesn't have enough money or crystals (cantBuy / notEnoughCrystals).
- Added: Set both buyVault and buyCrystals to 0 to prevent the user buying that item.