### PR TITLE
Add options to disable natural mob and/or animal spawns

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
+++ b/src/main/java/com/iridium/iridiumskyblock/IridiumSkyblock.java
@@ -167,7 +167,7 @@ public class IridiumSkyblock extends JavaPlugin {
                 shopGUI = new ShopGUI();
                 visitGUI = new HashMap<>();
 
-                registerListeners(new StructureGrowListener(), new EntitySpawnListener(), new BlockPistonListener(), new EntityPickupItemListener(), new PlayerTalkListener(), new ItemCraftListener(), new PlayerTeleportListener(), new PlayerPortalListener(), new BlockBreakListener(), new BlockPlaceListener(), new PlayerInteractListener(), new BlockFromToListener(), new SpawnerSpawnListener(), new EntityDeathListener(), new PlayerJoinLeaveListener(), new BlockGrowListener(), new PlayerTalkListener(), new PlayerMoveListener(), new EntityDamageByEntityListener(), new PlayerExpChangeListener(), new PlayerFishListener(), new EntityExplodeListener(), new PlayerBucketEmptyListener(), new EntityTargetLivingEntityListener());
+                registerListeners(new StructureGrowListener(), new EntitySpawnListener(), new BlockPistonListener(), new EntityPickupItemListener(), new PlayerTalkListener(), new ItemCraftListener(), new PlayerTeleportListener(), new PlayerPortalListener(), new BlockBreakListener(), new BlockPlaceListener(), new PlayerInteractListener(), new BlockFromToListener(), new SpawnerSpawnListener(), new EntityDeathListener(), new PlayerJoinLeaveListener(), new BlockGrowListener(), new PlayerTalkListener(), new PlayerMoveListener(), new EntityDamageByEntityListener(), new PlayerExpChangeListener(), new PlayerFishListener(), new EntityExplodeListener(), new PlayerBucketEmptyListener(), new EntityTargetLivingEntityListener(), new CreatureSpawnListener());
 
                 Bukkit.getScheduler().scheduleAsyncRepeatingTask(IridiumSkyblock.getInstance(), this::saveIslandManager, 0, 20 * 60);
 

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
@@ -56,8 +56,6 @@ public class Config {
     public boolean ignoreCooldownOnJoinCreation = false;
     public boolean enableBlockStacking = true;
     public boolean stripTopIslandPlaceholderColors = true;
-    public boolean disableNaturalMonsterSpawns = false;
-    public boolean disableNaturalAnimalSpawns = false;
     public int deleteBackupsAfterDays = 7;
     public int regenCooldown = 3600;
     public int distance = 151;
@@ -119,5 +117,8 @@ public class Config {
         public int crystals = 5;
         public XMaterial icon = XMaterial.GRASS_BLOCK;
     }
+
+    public boolean denyNaturalSpawnWhitelist = false;
+    public List<EntityType> denyNaturalSpawn = Arrays.asList(EntityType.PHANTOM);
 
 }

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
@@ -56,7 +56,7 @@ public class Config {
     public boolean ignoreCooldownOnJoinCreation = false;
     public boolean enableBlockStacking = true;
     public boolean stripTopIslandPlaceholderColors = true;
-    public boolean disableNaturalMobSpawns = false;
+    public boolean disableNaturalMonsterSpawns = false;
     public boolean disableNaturalAnimalSpawns = false;
     public int deleteBackupsAfterDays = 7;
     public int regenCooldown = 3600;

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
@@ -56,6 +56,8 @@ public class Config {
     public boolean ignoreCooldownOnJoinCreation = false;
     public boolean enableBlockStacking = true;
     public boolean stripTopIslandPlaceholderColors = true;
+    public boolean disableNaturalMobSpawns = false;
+    public boolean disableNaturalAnimalSpawns = false;
     public int deleteBackupsAfterDays = 7;
     public int regenCooldown = 3600;
     public int distance = 151;

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
@@ -2,7 +2,6 @@ package com.iridium.iridiumskyblock.listeners;
 
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.configs.Config;
-import com.iridium.iridiumskyblock.managers.IslandManager;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
@@ -7,8 +7,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.bukkit.entity.Monster;
-import org.bukkit.entity.Animals;
 
 public class CreatureSpawnListener implements Listener {
 
@@ -16,16 +14,18 @@ public class CreatureSpawnListener implements Listener {
     public void onCreatureSpawnEvent(CreatureSpawnEvent event) {
         try {
             final Config config = IridiumSkyblock.getConfiguration();
-            if (!config.disableNaturalAnimalSpawns && !config.disableNaturalMonsterSpawns) return;
+            if (config.denyNaturalSpawn.isEmpty() || event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
 
             final Entity entity = event.getEntity();
             final Location location = entity.getLocation();
-            if (!IridiumSkyblock.getIslandManager().isIslandWorld(location) || event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
+            if (!IridiumSkyblock.getIslandManager().isIslandWorld(location)) return;
 
-            if ((entity instanceof Monster && config.disableNaturalMonsterSpawns) || (entity instanceof Animals && config.disableNaturalAnimalSpawns)) {
+            if ((!config.denyNaturalSpawnWhitelist && config.denyNaturalSpawn.contains(entity.getType()))
+                    || (config.denyNaturalSpawnWhitelist && !config.denyNaturalSpawn.contains(entity.getType()))) {
                 event.setCancelled(true);
                 return;
             }
+
         } catch (Exception e) {
             IridiumSkyblock.getInstance().sendErrorMessage(e);
         }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
@@ -16,14 +16,14 @@ public class CreatureSpawnListener implements Listener {
     public void onCreatureSpawnEvent(CreatureSpawnEvent event) {
 
         Config config = IridiumSkyblock.getConfiguration();
-        if (!config.disableNaturalAnimalSpawns && !config.disableNaturalMobSpawns) return;
+        if (!config.disableNaturalAnimalSpawns && !config.disableNaturalMonsterSpawns) return;
         if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
 
         final Location location = event.getEntity().getLocation();
         final IslandManager islandManager = IridiumSkyblock.getIslandManager();
         if (!islandManager.isIslandWorld(location)) return;
 
-        if ((event.getEntity() instanceof Monster && config.disableNaturalMobSpawns) || (event.getEntity() instanceof Animals && config.disableNaturalAnimalSpawns)) {
+        if ((event.getEntity() instanceof Monster && config.disableNaturalMonsterSpawns) || (event.getEntity() instanceof Animals && config.disableNaturalAnimalSpawns)) {
             event.setCancelled(true);
             return;
         }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
@@ -23,9 +23,7 @@ public class CreatureSpawnListener implements Listener {
             if ((!config.denyNaturalSpawnWhitelist && config.denyNaturalSpawn.contains(entity.getType()))
                     || (config.denyNaturalSpawnWhitelist && !config.denyNaturalSpawn.contains(entity.getType()))) {
                 event.setCancelled(true);
-                return;
             }
-
         } catch (Exception e) {
             IridiumSkyblock.getInstance().sendErrorMessage(e);
         }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
@@ -16,11 +16,12 @@ public class CreatureSpawnListener implements Listener {
     public void onCreatureSpawnEvent(CreatureSpawnEvent event) {
         try {
             final Config config = IridiumSkyblock.getConfiguration();
+            if (!config.disableNaturalAnimalSpawns && !config.disableNaturalMonsterSpawns) return;
+
             final Entity entity = event.getEntity();
             final Location location = entity.getLocation();
-            if (!IridiumSkyblock.getIslandManager().isIslandWorld(location) || event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL || (!config.disableNaturalAnimalSpawns && !config.disableNaturalMonsterSpawns)) {
-                return;
-            }
+            if (!IridiumSkyblock.getIslandManager().isIslandWorld(location) || event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
+
             if ((entity instanceof Monster && config.disableNaturalMonsterSpawns) || (entity instanceof Animals && config.disableNaturalAnimalSpawns)) {
                 event.setCancelled(true);
                 return;

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
@@ -4,6 +4,7 @@ import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.configs.Config;
 import com.iridium.iridiumskyblock.managers.IslandManager;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -14,20 +15,20 @@ public class CreatureSpawnListener implements Listener {
 
     @EventHandler
     public void onCreatureSpawnEvent(CreatureSpawnEvent event) {
-
-        Config config = IridiumSkyblock.getConfiguration();
-        if (!config.disableNaturalAnimalSpawns && !config.disableNaturalMonsterSpawns) return;
-        if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
-
-        final Location location = event.getEntity().getLocation();
-        final IslandManager islandManager = IridiumSkyblock.getIslandManager();
-        if (!islandManager.isIslandWorld(location)) return;
-
-        if ((event.getEntity() instanceof Monster && config.disableNaturalMonsterSpawns) || (event.getEntity() instanceof Animals && config.disableNaturalAnimalSpawns)) {
-            event.setCancelled(true);
-            return;
+        try {
+            final Config config = IridiumSkyblock.getConfiguration();
+            final Entity entity = event.getEntity();
+            final Location location = entity.getLocation();
+            if (!IridiumSkyblock.getIslandManager().isIslandWorld(location) || event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL || (!config.disableNaturalAnimalSpawns && !config.disableNaturalMonsterSpawns)) {
+                return;
+            }
+            if ((entity instanceof Monster && config.disableNaturalMonsterSpawns) || (entity instanceof Animals && config.disableNaturalAnimalSpawns)) {
+                event.setCancelled(true);
+                return;
+            }
+        } catch (Exception e) {
+            IridiumSkyblock.getInstance().sendErrorMessage(e);
         }
-
     }
 
 }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/CreatureSpawnListener.java
@@ -1,0 +1,33 @@
+package com.iridium.iridiumskyblock.listeners;
+
+import com.iridium.iridiumskyblock.IridiumSkyblock;
+import com.iridium.iridiumskyblock.configs.Config;
+import com.iridium.iridiumskyblock.managers.IslandManager;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Animals;
+
+public class CreatureSpawnListener implements Listener {
+
+    @EventHandler
+    public void onCreatureSpawnEvent(CreatureSpawnEvent event) {
+
+        Config config = IridiumSkyblock.getConfiguration();
+        if (!config.disableNaturalAnimalSpawns && !config.disableNaturalMobSpawns) return;
+        if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
+
+        final Location location = event.getEntity().getLocation();
+        final IslandManager islandManager = IridiumSkyblock.getIslandManager();
+        if (!islandManager.isIslandWorld(location)) return;
+
+        if ((event.getEntity() instanceof Monster && config.disableNaturalMobSpawns) || (event.getEntity() instanceof Animals && config.disableNaturalAnimalSpawns)) {
+            event.setCancelled(true);
+            return;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Adds config option to control natural mob spawns in Iridium worlds. Added a whitelist toggle so you can deny anything except what's listed. That way if you only want (e.g.) sheep to spawn, you don't have to add the remaining 30+ mobs to the list.

I used the name denyNaturalSpawn as I wondered if 'entityBlacklist' would be too similar to 'blockedEntities' or cause confusion with two entity references? Can be changed if you wanted.