### PR TITLE
Add permission to allow bypassing of /is visit restrictions

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/Island.java
+++ b/src/main/java/com/iridium/iridiumskyblock/Island.java
@@ -842,7 +842,7 @@ public class Island {
         if (User.getUser(p).teleportingHome) {
             return;
         }
-        if (isBanned(User.getUser(p)) && !members.contains(p.getUniqueId().toString())) {
+        if (isBanned(User.getUser(p)) && !members.contains(p.getUniqueId().toString()) && !p.hasPermission("iridiumskyblock.visitbypass")) {
             p.sendMessage(Utils.color(IridiumSkyblock.getMessages().bannedFromIsland.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
             return;
         }

--- a/src/main/java/com/iridium/iridiumskyblock/commands/ExpelCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/ExpelCommand.java
@@ -33,7 +33,7 @@ public class ExpelCommand extends Command {
             if (visitor != null) {
                 if (!island.equals(User.getUser(visitor).getIsland())) {
                     if (island.isInIsland(visitor.getLocation())) {
-                        if (!(User.getUser(visitor).bypassing)) {
+                        if (!(User.getUser(visitor).bypassing) && !visitor.hasPermission("iridiumskyblock.visitbypass")) {
                             island.spawnPlayer(visitor);
                             sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().expelledVisitor.replace("%player%", visitor.getName()).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                             visitor.sendMessage(Utils.color(IridiumSkyblock.getMessages().youHaveBeenExpelled.replace("%kicker%", p.getName()).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));

--- a/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/PrivateCommand.java
@@ -25,7 +25,9 @@ public class PrivateCommand extends Command {
                 user.getIsland().setVisit(false);
                 int visitorCount = 0;
                 for (Player visitor : user.getIsland().getPlayersOnIsland()) {
-                    if (user.getIsland().equals(User.getUser(visitor).getIsland()) || User.getUser(visitor).bypassing || user.getIsland().isCoop(User.getUser(visitor).getIsland())) continue;
+                    if (user.getIsland().equals(User.getUser(visitor).getIsland()) || User.getUser(visitor).bypassing || user.getIsland().isCoop(User.getUser(visitor).getIsland()) || visitor.hasPermission("iridiumskyblock.visitbypass"))
+                        continue;
+
                     user.getIsland().spawnPlayer(visitor);
                     visitor.sendMessage(Utils.color(IridiumSkyblock.getMessages().expelledIslandLocked
                             .replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)

--- a/src/main/java/com/iridium/iridiumskyblock/commands/VisitCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/VisitCommand.java
@@ -28,7 +28,7 @@ public class VisitCommand extends Command {
         OfflinePlayer player = Bukkit.getOfflinePlayer(args[1]);
         User user = User.getUser(player);
         if (user.getIsland() != null) {
-            if (user.getIsland().isVisit() || User.getUser(p).bypassing) {
+            if (user.getIsland().isVisit() || User.getUser(p).bypassing || p.hasPermission("iridiumskyblock.visitbypass")) {
                 user.getIsland().teleportHome(p);
             } else {
                 sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().playersIslandIsPrivate.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));

--- a/src/main/java/com/iridium/iridiumskyblock/gui/VisitorGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/VisitorGUI.java
@@ -58,7 +58,7 @@ public class VisitorGUI extends GUI implements Listener {
             if (visitors.containsKey(i)) {
                 Player visitor = visitors.get(i);
                 if (island.isInIsland(visitor.getLocation())) {
-                    if (User.getUser(visitor).bypassing) {
+                    if (User.getUser(visitor).bypassing || visitor.hasPermission("iridiumskyblock.visitbypass")) {
                         e.getWhoClicked().sendMessage(Utils.color(IridiumSkyblock.getMessages().cantExpelPlayer.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix).replace("%player%", visitor.getName() + "")));
                     } else {
                         island.spawnPlayer(visitor);

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerMoveListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerMoveListener.java
@@ -34,7 +34,7 @@ public class PlayerMoveListener implements Listener {
             if (event.getFrom().getX() != event.getTo().getX() || event.getFrom().getZ() != event.getTo().getZ() || event.getFrom().getY() != event.getTo().getY() && event.getTo().getY() < 0) {
                 final Island island = IslandManager.getIslandViaLocation(location);
 
-                if (island != null && !island.isVisit() && !island.equals(userIsland) && !island.isCoop(userIsland) && !user.bypassing) {
+                if (island != null && !island.isVisit() && !island.equals(userIsland) && !island.isCoop(userIsland) && !user.bypassing && !player.hasPermission("iridiumskyblock.visitbypass")) {
                     island.spawnPlayer(event.getPlayer());
                     return;
                 }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerTeleportListener.java
@@ -39,7 +39,7 @@ public class PlayerTeleportListener implements Listener {
             }
             if (user.islandID == toIsland.getId()) return;
 
-            if ((toIsland.isVisit() && !toIsland.isBanned(user)) || user.bypassing) {
+            if ((toIsland.isVisit() && !toIsland.isBanned(user)) || user.bypassing || player.hasPermission("iridiumskyblock.visitbypass")) {
                 if (!toIsland.isInIsland(fromLocation)) {
                     Bukkit.getScheduler().scheduleSyncDelayedTask(IridiumSkyblock.getInstance(), () -> toIsland.sendBorder(player), 1);
                     if (user.islandID != toIsland.getId()) {


### PR DESCRIPTION
Allows players with the permission `iridiumskyblock.visitbypass` to visit private islands and also make them exempt from being expelled/banned. Basically the 'visit' equivalent of /is bypass.

I think I covered all of the events that this permission would apply to.