### PR TITLE
Fix entities not being able to target island members

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/listeners/EntityTargetLivingEntityListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/EntityTargetLivingEntityListener.java
@@ -2,7 +2,6 @@ package com.iridium.iridiumskyblock.listeners;
 
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.Island;
-import com.iridium.iridiumskyblock.Role;
 import com.iridium.iridiumskyblock.User;
 import com.iridium.iridiumskyblock.managers.IslandManager;
 import org.bukkit.GameMode;
@@ -58,7 +57,7 @@ public class EntityTargetLivingEntityListener implements Listener {
 
         // Check if the player is a guest
         User user = User.getUser(targetedPlayer);
-        if (user.getRole() == Role.Visitor) {
+        if (!island.members.contains(user.player)) {
             // Cancel the event because the player is a guest
             event.setCancelled(true);
 
@@ -67,7 +66,7 @@ public class EntityTargetLivingEntityListener implements Listener {
             if (playersOnIsland.size() != 1) {
                 List<Player> possibleTargets = playersOnIsland.stream()
                         .filter(player -> player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR)
-                        .filter(player -> User.getUser(player).getRole() != Role.Visitor)
+                        .filter(player -> island.members.contains(User.getUser(player).player))
                         .filter(entity::hasLineOfSight)
                         .collect(Collectors.toList());
 

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/EntityTargetLivingEntityListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/EntityTargetLivingEntityListener.java
@@ -2,6 +2,7 @@ package com.iridium.iridiumskyblock.listeners;
 
 import com.iridium.iridiumskyblock.IridiumSkyblock;
 import com.iridium.iridiumskyblock.Island;
+import com.iridium.iridiumskyblock.Role;
 import com.iridium.iridiumskyblock.User;
 import com.iridium.iridiumskyblock.managers.IslandManager;
 import org.bukkit.GameMode;
@@ -57,7 +58,7 @@ public class EntityTargetLivingEntityListener implements Listener {
 
         // Check if the player is a guest
         User user = User.getUser(targetedPlayer);
-        if (user.islandID != island.id) {
+        if (user.getRole() == Role.Visitor) {
             // Cancel the event because the player is a guest
             event.setCancelled(true);
 
@@ -66,7 +67,7 @@ public class EntityTargetLivingEntityListener implements Listener {
             if (playersOnIsland.size() != 1) {
                 List<Player> possibleTargets = playersOnIsland.stream()
                         .filter(player -> player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR)
-                        .filter(player -> User.getUser(player).islandID == island.id)
+                        .filter(player -> User.getUser(player).getRole() != Role.Visitor)
                         .filter(entity::hasLineOfSight)
                         .collect(Collectors.toList());
 


### PR DESCRIPTION
Fix issue described in #479 by replacing the owner check with a member check.