### PR TITLE
Fix & Clarify IslandDemoteEvent (#528)

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/api/IslandDemoteEvent.java
+++ b/src/main/java/com/iridium/iridiumskyblock/api/IslandDemoteEvent.java
@@ -32,15 +32,17 @@ public class IslandDemoteEvent extends IslandEvent implements Cancellable {
         this.cancelled = b;
     }
 
+    @NotNull
     public User getTarget() {
         return target;
     }
 
+    @NotNull
     public User getDemoter() {
         return demoter;
     }
 
-    public Role getRole() {
+    public Role getNewRole() {
         return role;
     }
 }

--- a/src/main/java/com/iridium/iridiumskyblock/gui/MembersGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/MembersGUI.java
@@ -85,7 +85,7 @@ public class MembersGUI extends GUI implements Listener {
                                         e.getWhoClicked().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().noPermission.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
                                     }
                                 } else {
-                                    IslandDemoteEvent event = new IslandDemoteEvent(island, u, user, Role.getViaRank(u.getRole().rank + 1));
+                                    IslandDemoteEvent event = new IslandDemoteEvent(island, u, user, Role.getViaRank(u.getRole().rank - 1));
                                     Bukkit.getPluginManager().callEvent(event);
                                     if (!event.isCancelled()) {
                                         u.role = Role.getViaRank(u.getRole().rank - 1);


### PR DESCRIPTION
Fixes #528 as suggested.

This change will break the API but also clarify what the role in the IslandDemoteEvent is.