### PR TITLE
Fix island being not visitable for coop members (#484)

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/User.java
+++ b/src/main/java/com/iridium/iridiumskyblock/User.java
@@ -107,4 +107,12 @@ public class User {
     public void save(Connection connection) {
         UserManager.saveUser(this, connection);
     }
+
+    public boolean hasCoopVisitPermissions(User otherUser) {
+        return IridiumSkyblock.getInstance().getConfiguration().coopPrivateIslandAccess &&
+                this.getIsland() != null &&
+                otherUser.getIsland() != null &&
+                getIsland().isCoop(otherUser.getIsland());
+    }
+
 }

--- a/src/main/java/com/iridium/iridiumskyblock/commands/VisitCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/VisitCommand.java
@@ -30,9 +30,11 @@ public class VisitCommand extends Command {
         }
         OfflinePlayer player = Bukkit.getOfflinePlayer(args[1]);
         User user = User.getUser(player);
-        if (user.getIsland() != null) {
-            if (user.getIsland().visit || User.getUser(p).bypassing || p.hasPermission("iridiumskyblock.visitbypass")) {
-                user.getIsland().teleportHome(p);
+        User commandExecutor = User.getUser(p);
+        Island island = user.getIsland();
+        if (island != null) {
+            if (island.visit || User.getUser(p).bypassing || p.hasPermission("iridiumskyblock.visitbypass") || user.hasCoopVisitPermissions(commandExecutor)) {
+                island.teleportHome(p);
             } else {
                 sender.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().playersIslandIsPrivate.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
             }

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Config.java
@@ -56,6 +56,7 @@ public class Config {
     public boolean stripTopIslandPlaceholderColors = true;
     public boolean denyNaturalSpawnWhitelist = false;
     public boolean stackableBoosters = true;
+    public boolean coopPrivateIslandAccess = true;
     public int deleteBackupsAfterDays = 7;
     public int regenCooldown = 3600;
     public int distance = 151;

--- a/src/main/java/com/iridium/iridiumskyblock/gui/CoopGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/CoopGUI.java
@@ -72,7 +72,7 @@ public class CoopGUI extends GUI implements Listener {
                         e.getWhoClicked().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().noPermission.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
                     }
                 } else {
-                    if (island.visit || u.bypassing) {
+                    if (island.visit || u.bypassing || User.getUser(island.owner).hasCoopVisitPermissions(u)) {
                         island.teleportHome((Player) e.getWhoClicked());
                     } else {
                         e.getWhoClicked().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().playersIslandIsPrivate.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));

--- a/src/main/java/com/iridium/iridiumskyblock/gui/VisitGUI.java
+++ b/src/main/java/com/iridium/iridiumskyblock/gui/VisitGUI.java
@@ -10,7 +10,6 @@ import com.iridium.iridiumskyblock.utils.ItemStackUtils;
 import com.iridium.iridiumskyblock.utils.Placeholder;
 import com.iridium.iridiumskyblock.utils.StringUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -61,10 +60,11 @@ public class VisitGUI extends GUI implements Listener {
         if (e.getInventory().equals(getInventory())) {
             e.setCancelled(true);
             if (e.getClickedInventory() == null || !e.getClickedInventory().equals(getInventory())) return;
+            Player player = (Player) e.getWhoClicked();
             if (islands.containsKey(e.getSlot())) {
                 Island island = IslandManager.getIslandViaId(islands.get(e.getSlot()));
-                User u = User.getUser((OfflinePlayer) e.getWhoClicked());
-                if (island.visit || u.bypassing) {
+                User u = User.getUser(player);
+                if (island.visit || u.bypassing || User.getUser(island.owner).hasCoopVisitPermissions(u)) {
                     if (e.getClick() == ClickType.RIGHT) {
                         if (island.hasVoted(u)) {
                             island.removeVote(u);
@@ -72,23 +72,23 @@ public class VisitGUI extends GUI implements Listener {
                             island.addVote(u);
                         }
                     } else {
-                        e.getWhoClicked().closeInventory();
-                        island.teleportHome((Player) e.getWhoClicked());
+                        player.closeInventory();
+                        island.teleportHome(player);
                     }
                 } else {
-                    e.getWhoClicked().sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().playersIslandIsPrivate.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
+                    player.sendMessage(StringUtils.color(IridiumSkyblock.getInstance().getMessages().playersIslandIsPrivate.replace("%prefix%", IridiumSkyblock.getInstance().getConfiguration().prefix)));
                 }
             } else if (e.getSlot() == getInventory().getSize() - 7) {
                 VisitGUI visitGUI = IridiumSkyblock.getInstance().getVisitGUI().getPage(page - 1);
                 if (visitGUI != null) {
                     visitGUI.addContent();
-                    e.getWhoClicked().openInventory(visitGUI.getInventory());
+                    player.openInventory(visitGUI.getInventory());
                 }
             } else if (e.getSlot() == getInventory().getSize() - 3) {
                 VisitGUI visitGUI = IridiumSkyblock.getInstance().getVisitGUI().getPage(page + 1);
                 if (visitGUI != null) {
                     visitGUI.addContent();
-                    e.getWhoClicked().openInventory(visitGUI.getInventory());
+                    player.openInventory(visitGUI.getInventory());
                 }
             }
         }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerMoveListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerMoveListener.java
@@ -34,7 +34,7 @@ public class PlayerMoveListener implements Listener {
             final Island island = IslandManager.getIslandViaLocation(location);
             final boolean hasCoopVisitPermissions = User.getUser(island.owner).hasCoopVisitPermissions(user);
 
-            if (island != null && !island.visit && !island.equals(userIsland) && hasCoopVisitPermissions && !user.bypassing && !player.hasPermission("iridiumskyblock.visitbypass")) {
+            if (island != null && !island.visit && !island.equals(userIsland) && !hasCoopVisitPermissions && !user.bypassing && !player.hasPermission("iridiumskyblock.visitbypass")) {
                 island.spawnPlayer(event.getPlayer());
                 return;
             }

--- a/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerMoveListener.java
+++ b/src/main/java/com/iridium/iridiumskyblock/listeners/PlayerMoveListener.java
@@ -32,8 +32,9 @@ public class PlayerMoveListener implements Listener {
 
         if (event.getFrom().getX() != event.getTo().getX() || event.getFrom().getZ() != event.getTo().getZ() || event.getFrom().getY() != event.getTo().getY() && event.getTo().getY() < 0) {
             final Island island = IslandManager.getIslandViaLocation(location);
+            final boolean hasCoopVisitPermissions = User.getUser(island.owner).hasCoopVisitPermissions(user);
 
-            if (island != null && !island.visit && !island.equals(userIsland) && !island.isCoop(userIsland) && !user.bypassing && !player.hasPermission("iridiumskyblock.visitbypass")) {
+            if (island != null && !island.visit && !island.equals(userIsland) && hasCoopVisitPermissions && !user.bypassing && !player.hasPermission("iridiumskyblock.visitbypass")) {
                 island.spawnPlayer(event.getPlayer());
                 return;
             }


### PR DESCRIPTION
Fixes #484 by letting coop members join a coop island, regardless if it's private. Also introduces a config option for people who want the old behavior.